### PR TITLE
docSidebar, docs: switch to using a yaml file to define sidebar format

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,19 +42,26 @@ At the top of each documentation page you should include frontmatter so that the
 
 ```
 ---
-title: This is what will be shown in the sidebar
 path: This is the route to the page that all links will be created from.
-section: This is the section that the doc will be created under in the sidebar.
 ---
 ```
 For example:
 ```
 ---
-title: "Installation"
-path: /docs/getting-started/installation
-section: Getting Started
+path: /docs/getting-started/quick-start
 ---
 ```
+
+To add the doc to the side menu you must add it to the `sidebar.yaml` in `content/docs`. A section is defined as followed:
+```
+- title (optional): Getting Started
+  items:
+    - title: Installation
+      path: /docs/getting-started/installation
+    - title: Quick Start
+      path: /docs/getting-started/quick-start
+```
+**Note:** `title` for the section is optional but the `title` for each menu item is required.
 
 2. Run the developement server
 ```

--- a/content/docs/getting-started/installation.md
+++ b/content/docs/getting-started/installation.md
@@ -1,7 +1,5 @@
 ---
-title: "Installation"
 path: /docs/getting-started/installation
-section: Getting Started
 ---
 # Installing Appsody
 

--- a/content/docs/getting-started/quick-start.md
+++ b/content/docs/getting-started/quick-start.md
@@ -1,7 +1,5 @@
 ---
-title: Quick Start
 path: /docs/getting-started/quick-start
-section: Getting Started
 ---
 
 # Appsody Quick Start

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1,5 +1,4 @@
 ---
-title: "Overview"
 path: /docs
 ---
 # Welcome to Appsody

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -1,0 +1,27 @@
+- items:
+    - title: Overview
+      path: /docs
+- title: Getting Started
+  items:
+    - title: Installation
+      path: /docs/getting-started/installation
+    - title: Quick Start
+      path: /docs/getting-started/quick-start
+- title: Using Appsody
+  items:
+    - title: Local Development
+      path: /docs/using-appsody/local-development
+    - title: Creating Projects
+      path: /docs/using-appsody/creating-project
+    - title: Building and Deploying
+      path: /docs/using-appsody/building-and-deploying
+    - title: CLI Reference
+      path: /docs/using-appsody/cli-commands
+- title: Appsody Stacks
+  items:
+    - title: Stacks Overview
+      path: /docs/stacks/stacks-overview
+    - title: Creating and Modifying Stacks
+      path: /docs/stacks/create-or-modify
+    - title: Stack Structure
+      path: /docs/stacks/stack-structure

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -9,10 +9,10 @@
       path: /docs/getting-started/quick-start
 - title: Using Appsody
   items:
-    - title: Local Development
-      path: /docs/using-appsody/local-development
     - title: Creating Projects
       path: /docs/using-appsody/creating-project
+    - title: Local Development
+      path: /docs/using-appsody/local-development
     - title: Building and Deploying
       path: /docs/using-appsody/building-and-deploying
     - title: CLI Reference
@@ -21,7 +21,7 @@
   items:
     - title: Stacks Overview
       path: /docs/stacks/stacks-overview
-    - title: Creating and Modifying Stacks
+    - title: Creating and Modifying
       path: /docs/stacks/create-or-modify
     - title: Stack Structure
       path: /docs/stacks/stack-structure

--- a/content/docs/stacks/create-or-modify.md
+++ b/content/docs/stacks/create-or-modify.md
@@ -19,9 +19,9 @@ The quickest way to create an Appsody stack from scratch is to build from the [s
     cd docs/sample-stack
     ```
 
-1. Create your stack. See [structure of a stack](/docs/stacks/stack-structure.md) for a guide on what makes a stack.
+2. Create your stack. See [structure of a stack](/docs/stacks/stack-structure.md) for a guide on what makes a stack.
 
-2. In the image folder build your stack image:
+3. In the image folder build your stack image:
 
     ```bash
     docker build -t <user>/<my-stack> -f Dockerfile-stack .

--- a/content/docs/stacks/create-or-modify.md
+++ b/content/docs/stacks/create-or-modify.md
@@ -1,7 +1,5 @@
 ---
-title: "Creating and Modifying Stacks"
 path: /docs/stacks/create-or-modify
-section: Appsody Stacks
 ---
 # Creating and Modifying Stacks
 
@@ -21,9 +19,9 @@ The quickest way to create an Appsody stack from scratch is to build from the [s
     cd docs/sample-stack
     ```
 
-2. Create your stack. See [structure of a stack](/docs/stacks/stack-structure.md) for a guide on what makes a stack.
+1. Create your stack. See [structure of a stack](/docs/stacks/stack-structure.md) for a guide on what makes a stack.
 
-3. In the image folder build your stack image:
+2. In the image folder build your stack image:
 
     ```bash
     docker build -t <user>/<my-stack> -f Dockerfile-stack .

--- a/content/docs/stacks/stack-structure.md
+++ b/content/docs/stacks/stack-structure.md
@@ -1,7 +1,5 @@
 ---
-title: "Stack Structure"
 path: /docs/stacks/stack-structure
-section: Appsody Stacks
 ---
 ## Stack structure
 ```bash

--- a/content/docs/stacks/stacks-overview.md
+++ b/content/docs/stacks/stacks-overview.md
@@ -1,7 +1,5 @@
 ---
-title: "Stacks Overview"
 path: /docs/stacks/stacks-overview
-section: Appsody Stacks
 ---
 # Appsody Stacks
 

--- a/content/docs/using-appsody/building-and-deploying.md
+++ b/content/docs/using-appsody/building-and-deploying.md
@@ -1,6 +1,4 @@
 ---
-title: "Building and Deploying"
-section: Using Appsody
 path: /docs/using-appsody/building-and-deploying
 ---
 

--- a/content/docs/using-appsody/cli-commands.md
+++ b/content/docs/using-appsody/cli-commands.md
@@ -1,7 +1,5 @@
 ---
-title: CLI Reference
 path: /docs/using-appsody/cli-commands
-section: Using Appsody
 ---
 # Appsody CLI
 ## appsody

--- a/content/docs/using-appsody/creating-project.md
+++ b/content/docs/using-appsody/creating-project.md
@@ -1,6 +1,4 @@
 ---
-title: Creating Projects
-section: Using Appsody
 path: /docs/using-appsody/creating-project
 ---
 

--- a/content/docs/using-appsody/installing-knative-locally.md
+++ b/content/docs/using-appsody/installing-knative-locally.md
@@ -1,6 +1,4 @@
 ---
-title: "Installing Knative Locally"
-section: Using Appsody
 path: /docs/using-appsody/installing-knative-locally
 ---
 

--- a/content/docs/using-appsody/local-development.md
+++ b/content/docs/using-appsody/local-development.md
@@ -1,6 +1,4 @@
 ---
-title: "Local Development"
-section: Using Appsody
 path: /docs/using-appsody/local-development
 ---
 

--- a/src/components/docSidebar.js
+++ b/src/components/docSidebar.js
@@ -1,8 +1,8 @@
 import React from "react";
-import { Link, StaticQuery, graphql } from "gatsby"
+import { Link } from "gatsby"
+import navStructure from "../../content/docs/sidebar.yaml";
 
 const DocSection = (props) => {
-
     return (
         <React.Fragment>
             {
@@ -10,34 +10,17 @@ const DocSection = (props) => {
             }
             <ul>
                 {
-                    props.data.map(doc => <li className="my-1"><Link to={doc.path}>{doc.title}</Link></li>)
+                    props.data.map(doc => <li key={doc.title} className="my-1"><Link to={doc.path}>{doc.title}</Link></li>)
                 }
             </ul>
         </React.Fragment>
     );
 }
 
-const DocSidebar = ({ data }) => {
-    const docs = data.allMarkdownRemark.nodes;
-    const sections = {};
-    sections["null"] = [];
-
-    docs.forEach(doc => {
-        const data = doc.frontmatter;
-        if (!sections[data.section]) sections[data.section] = [];
-        sections[data.section].push({
-            title: data.title,
-            path: data.path,
-            weight: data.weight
-        });
-    });
-
+const DocSidebar = () => {
     let list = [];
-    list.push(<DocSection key={sections["null"].title} title={"null"} data={sections["null"]}/>)
-    delete sections["null"];
-
-    for (let section in sections) {
-        list.push(<DocSection key={sections[section].title} title={section} data={sections[section]}/>)
+    for (let section of navStructure) {
+        list.push(<DocSection key={section.title} title={section.title} data={section.items}/>)
     }
 
     return (
@@ -52,21 +35,4 @@ const DocSidebar = ({ data }) => {
     )
 }
 
-export default (props) => (
-    <StaticQuery
-      query={graphql`
-        query {
-            allMarkdownRemark {
-                nodes {
-                    frontmatter {
-                        section
-                        title
-                        path
-                    }
-                }
-            }
-        }
-      `}
-      render={data => <DocSidebar data={data} {...props} />}
-    />
-  )
+export default DocSidebar;


### PR DESCRIPTION
## Checklist

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](../DEVELOPMENT.md).
- [x] relevant documentation updated

## Description
Switch to a yaml file to define the structure of the docs sidebar. 
This allows us to:
- easily control the weighting of both sections and their contents.
- have sections without a title
- what documentation is shown in the sidebar and what is hidden

## Related Issues
fixes: https://github.com/appsody/website/issues/46