### PR TITLE
styles: limit active link highlight to the docs sidebar

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -350,6 +350,6 @@ footer a:hover {
   display: none;
 }
 
-.active{
-  color: var( --colour-scheme-1) !important;
+#docs-sidebar .active{
+  color: var( --colour-scheme-1);
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
Limited the highlight for active page only on links in the docs sidebar

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #32, Related to #54, etc.
-->
refs: https://github.com/appsody/website/pull/125