### PR TITLE
docs: update clone url of sample-stack

### DIFF
--- a/content/docs/stacks/create-or-modify.md
+++ b/content/docs/stacks/create-or-modify.md
@@ -15,8 +15,8 @@ The quickest way to create an Appsody stack from scratch is to build from the [s
 
 1. Clone the sample:
     ```bash
-    git clone https://github.com/appsody/docs
-    cd docs/sample-stack
+    git clone https://github.com/appsody/stacks
+    cd stacks/samples/sample-stack/
     ```
 
 2. Create your stack. See [structure of a stack](/docs/stacks/stack-structure.md) for a guide on what makes a stack.


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description

The 'Creating a stack' page provides steps to clone the sample stack. The url it uses points at the old docs repo.

This PR updates the clone url as well as the directory the user should then change into, to match the new location in the stacks repo.
