### PR TITLE
docs: fix typo in stack structure

### DIFF
--- a/content/docs/stacks/stack-structure.md
+++ b/content/docs/stacks/stack-structure.md
@@ -49,5 +49,5 @@ A template is a pre-configured starter application that is ready to use with a p
 The `.appsody-config.yaml` allows you to specify the image which the template will use.
 For example, the following specifies that the template will use the nodejs-express image: 
 ```
-image: nodejs-express:0.2.0
+stack: nodejs-express:0.2.0
 ```


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Fixes typo referencing `image` instead of `stack`
