### PR TITLE
website: add padding to tiles

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -158,7 +158,7 @@ section.landing-section h2 {
 }
 
 .tile {
-  padding: 2em 0;
+  padding: 2em 0.5em;
   position: relative;
 }
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
<!-- Write a brief description of the changes introduced by this PR -->
The description in the tiles look a little too close to the edge, suggesting we add some padding to make the text look less cramped. For example take a look at the Quarkus description..

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #32, Related to #54, etc.
-->
**before:**
![Screenshot 2019-08-12 at 16 42 29](https://user-images.githubusercontent.com/25488126/62878129-61dd3180-bd20-11e9-8a5f-8e357b6b65c5.png)

**after:**
![Screenshot 2019-08-12 at 16 44 45](https://user-images.githubusercontent.com/25488126/62878199-86390e00-bd20-11e9-8ff0-eeea4ae530a0.png)

