### PR TITLE
docs: pinned footer to bottom of page regardless of page height

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -15,6 +15,10 @@
 
 }
 
+html {
+  height: 100%;
+}
+
 body {
   position: relative;
   min-height: 100%;
@@ -390,7 +394,6 @@ footer a:hover {
 }
 
 .doc-content {
-  min-height: calc(100vh - 10.5em);
   padding-bottom: 3em;
 }
 
@@ -450,8 +453,4 @@ footer a:hover {
 
 .hide {
   display: none;
-}
-
-html {
-  height: 100%;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -16,6 +16,8 @@
 }
 
 body {
+  position: relative;
+  min-height: 100%;
   font-family: 'Open Sans', sans-serif;
 }
 
@@ -265,6 +267,10 @@ section.landing-section h2 {
 }
 
 footer {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
   background-color: var(--colour-scheme-1);
   box-shadow: 0 6px 29px var(--darker-grey);
   padding: 1em;
@@ -385,6 +391,7 @@ footer a:hover {
 
 .doc-content {
   min-height: calc(100vh - 10.5em);
+  padding-bottom: 3em;
 }
 
 .doc-content table {
@@ -443,4 +450,8 @@ footer a:hover {
 
 .hide {
   display: none;
+}
+
+html {
+  height: 100%;
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
Reintroduced a fix to pin the footer to the bottom of the page for short docs.

## Related Issues
Fixes: #161 