### PR TITLE
docs: fix links to build and test stacks page

### DIFF
--- a/content/docs/stacks/create.md
+++ b/content/docs/stacks/create.md
@@ -43,7 +43,7 @@ stack: <org-name>/<stack-id>
 If the stack is intended to be contributed to the  [Appsody stacks repository](https://github.com/appsody/stacks) the stack image should be called `appsody/<stack-name>:<stack-version>`.
 
 ## Building and testing stacks locally
-Now that have you have created a stack you can [build and test](/docs/stacks/run-locally) it locally.
+Now that have you have created a stack you can [build and test](/docs/stacks/build-and-test) it locally.
 
 ## Contributing a stack
 If you would like to contribute a new stack to the [stacks repository](https://github.com/appsody/stacks) the Appsody [contributing guildlines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) explains how.

--- a/content/docs/stacks/modify.md
+++ b/content/docs/stacks/modify.md
@@ -19,7 +19,7 @@ cd stacks
 
 ## Modifying the stack image
 
-If you have modified files within `/image` you will need to [build and test](/docs/stacks/run-locally) to make sure the stack and its templates are working as intended.
+If you have modified files within `/image` you will need to [build and test](/docs/stacks/build-and-test) to make sure the stack and its templates are working as intended.
 
 **Note:** You should test all other Appsody commands that the stack supports also.
 
@@ -43,4 +43,4 @@ appsody run
 ```
 
 ## Building and testing stacks locally
-Now that have you have created a stack you can [build and test](/docs/stacks/run-locally) it locally.
+Now that have you have created a stack you can [build and test](/docs/stacks/build-and-test) it locally.


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Fixes broken links. `/docs/stacks/run-locally` -> `/docs/stacks/build-and-test`

## Related issues
fixes: https://github.com/appsody/website/issues/188