### PR TITLE
Travis build: Update CLI documentation for release 0.4.0

### DIFF
--- a/content/docs/using-appsody/cli-commands.md
+++ b/content/docs/using-appsody/cli-commands.md
@@ -262,10 +262,12 @@ Initialize an Appsody project with a stack and template app
 
 This creates a new Appsody project in a local directory or sets up the local dev environment of an existing Appsody project.
 
-If the [repository] is not specified the default repository will be used. If no [template] is specified, the default template will be used.
+If the [repository] is not specified the default repository will be used. If no [template] is specified, the default template will be used. 
 With the [stack], [repository]/[stack], [stack] [template] or [repository]/[stack] [template] arguments, this command will setup a new Appsody project. It will create an Appsody stack config file, unzip a template app, and run the stack init script to setup the local dev environment. It is typically run on an empty directory and may fail
 if files already exist. See the --overwrite and --no-template options for more details.
 Use 'appsody list' to see the available stack options.
+
+If keyword "none" is specified instead of a [template], the project will be initialized to use Appsody, and no tempalte will be provided.
 
 Without the [stack] argument, this command must be run on an existing Appsody project and will only run the stack init script to
 setup the local dev environment.

--- a/content/docs/using-appsody/cli-commands.md
+++ b/content/docs/using-appsody/cli-commands.md
@@ -27,10 +27,11 @@ Complete documentation is available at https://appsody.dev
 * [appsody build](#appsody-build)	 - Locally build a docker image of your appsody project
 * [appsody completion](#appsody-completion)	 - Generates bash tab completions
 * [appsody debug](#appsody-debug)	 - Run the local Appsody environment in debug mode
-* [appsody deploy](#appsody-deploy)	 - Build and deploy your Appsody project on a local Kubernetes cluster
+* [appsody deploy](#appsody-deploy)	 - Build and deploy your Appsody project to your Kubernetes cluster
 * [appsody extract](#appsody-extract)	 - Extract the stack and your Appsody project to a local directory
 * [appsody init](#appsody-init)	 - Initialize an Appsody project with a stack and template app
 * [appsody list](#appsody-list)	 - List the Appsody stacks available to init
+* [appsody operator](#appsody-operator)	 - Install or uninstall the Appsody operator from your Kubernetes cluster.
 * [appsody repo](#appsody-repo)	 - Manage your Appsody repositories
 * [appsody run](#appsody-run)	 - Run the local Appsody environment for your project
 * [appsody stop](#appsody-stop)	 - Stops the local Appsody docker container for your project
@@ -52,8 +53,9 @@ appsody build [flags]
 ### Options
 
 ```
-  -h, --help         help for build
-  -t, --tag string   Docker image name and optionally a tag in the 'name:tag' format
+      --docker-options string   Additional options to be sent when running docker commands.  Value must be in "".
+  -h, --help                    help for build
+  -t, --tag string              Docker image name and optionally a tag in the 'name:tag' format
 ```
 
 ### Options inherited from parent commands
@@ -124,12 +126,13 @@ appsody debug [flags]
 ### Options
 
 ```
-      --deps-volume string    Docker volume to use for dependencies. Mounts to APPSODY_DEPS dir. (default "my-project-deps")
-  -h, --help                  help for debug
-      --name string           Assign a name to your development container. (default "my-project-dev")
-      --network string        Specify the network for docker to use.
-  -p, --publish stringArray   Publish the container's ports to the host. The stack's exposed ports will always be published, but you can publish addition ports or override the host ports with this option.
-  -P, --publish-all           Publish all exposed ports to random ports
+      --deps-volume string      Docker volume to use for dependencies. Mounts to APPSODY_DEPS dir. (default "my-project-deps")
+      --docker-options string   Specify the docker options to use.  Value must be in "".
+  -h, --help                    help for debug
+      --name string             Assign a name to your development container. (default "my-project-dev")
+      --network string          Specify the network for docker to use.
+  -p, --publish stringArray     Publish the container's ports to the host. The stack's exposed ports will always be published, but you can publish addition ports or override the host ports with this option.
+  -P, --publish-all             Publish all exposed ports to random ports
 ```
 
 ### Options inherited from parent commands
@@ -146,13 +149,12 @@ appsody debug [flags]
 
 ## appsody deploy
 
-Build and deploy your Appsody project on a local Kubernetes cluster
+Build and deploy your Appsody project to your Kubernetes cluster
 
 ### Synopsis
 
 This command extracts the code from your project, builds a local Docker image for deployment,
-generates a KNative serving deployment manifest (yaml) file, and deploys your image as a KNative
-service in your local cluster.
+generates a deployment manifest (yaml) file if one is not present, and uses it to deploy your image to Kubernetes.
 
 ```
 appsody deploy [flags]
@@ -161,6 +163,9 @@ appsody deploy [flags]
 ### Options
 
 ```
+  -f, --file string        The file name to use for the deployment configuration. (default "app-deploy.yaml")
+      --force              Force the reuse of the deployment configuration file if one exists.
+      --generate-only      Only generate the deployment configuration file. Do not deploy the project.
   -h, --help               help for deploy
   -n, --namespace string   Target namespace in your Kubernetes cluster
       --push               Push this image to an external Docker registry. Assumes that you have previously successfully done docker login
@@ -178,6 +183,43 @@ appsody deploy [flags]
 ### SEE ALSO
 
 * [appsody](#appsody)	 - Appsody CLI
+* [appsody deploy delete](#appsody-deploy-delete)	 - Delete your deployed Appsody project from a Kubernetes cluster
+
+## appsody deploy delete
+
+Delete your deployed Appsody project from a Kubernetes cluster
+
+### Synopsis
+
+This command deletes your deployed Appsody project from the configured Kubernetes cluster using your existing deployment manifest.
+
+```
+appsody deploy delete [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --config string      config file (default is $HOME/.appsody/.appsody.yaml)
+      --dryrun             Turns on dry run mode
+  -f, --file string        The file name to use for the deployment configuration. (default "app-deploy.yaml")
+      --force              Force the reuse of the deployment configuration file if one exists.
+      --generate-only      Only generate the deployment configuration file. Do not deploy the project.
+  -n, --namespace string   Target namespace in your Kubernetes cluster
+      --push               Push this image to an external Docker registry. Assumes that you have previously successfully done docker login
+  -t, --tag string         Docker image name and optionally a tag in the 'name:tag' format
+  -v, --verbose            Turns on debug output and logging to a file in $HOME/.appsody/logs
+```
+
+### SEE ALSO
+
+* [appsody deploy](#appsody-deploy)	 - Build and deploy your Appsody project to your Kubernetes cluster
 
 ## appsody extract
 
@@ -220,8 +262,8 @@ Initialize an Appsody project with a stack and template app
 
 This creates a new Appsody project in a local directory or sets up the local dev environment of an existing Appsody project.
 
-If the [repository] is not specified the default repository will be used.
-With the [stack] or [repository]/[stack] argument, this command will setup a new Appsody project. It will create an Appsody stack config file, unzip a template app, and run the stack init script to setup the local dev environment. It is typically run on an empty directory and may fail
+If the [repository] is not specified the default repository will be used. If no [template] is specified, the default template will be used.
+With the [stack], [repository]/[stack], [stack] [template] or [repository]/[stack] [template] arguments, this command will setup a new Appsody project. It will create an Appsody stack config file, unzip a template app, and run the stack init script to setup the local dev environment. It is typically run on an empty directory and may fail
 if files already exist. See the --overwrite and --no-template options for more details.
 Use 'appsody list' to see the available stack options.
 
@@ -229,15 +271,15 @@ Without the [stack] argument, this command must be run on an existing Appsody pr
 setup the local dev environment.
 
 ```
-appsody init [stack] or [repository]/[stack] [flags]
+appsody init [stack] or [repository]/[stack] [template] [flags]
 ```
 
 ### Options
 
 ```
   -h, --help          help for init
-      --no-template   Only create the .appsody-config.yaml file. Do not unzip the template project.
-      --overwrite     Download and extract the template project, overwriting existing files.
+      --no-template   Only create the .appsody-config.yaml file. Do not unzip the template project. [Deprecated]
+      --overwrite     Download and extract the template project, overwriting existing files.  This option is not intended to be used in Appsody project directories.
 ```
 
 ### Options inherited from parent commands
@@ -281,6 +323,100 @@ appsody list [repository] [flags]
 ### SEE ALSO
 
 * [appsody](#appsody)	 - Appsody CLI
+
+## appsody operator
+
+Install or uninstall the Appsody operator from your Kubernetes cluster.
+
+### Synopsis
+
+This command allows you to "install" or "uninstall" the Appsody operator from the configured Kubernetes cluster. An installed Appsody operator is required to deploy your Appsody projects.
+
+### Options
+
+```
+  -h, --help                help for operator
+  -n, --namespace string    The namespace in which the operator will run. (default "default")
+  -w, --watchspace string   The namespace which the operator will watch. Use '' for all namespaces. (default "''")
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default is $HOME/.appsody/.appsody.yaml)
+      --dryrun          Turns on dry run mode
+  -v, --verbose         Turns on debug output and logging to a file in $HOME/.appsody/logs
+```
+
+### SEE ALSO
+
+* [appsody](#appsody)	 - Appsody CLI
+* [appsody operator install](#appsody-operator-install)	 - Install the Appsody Operator into the configured Kubernetes cluster
+* [appsody operator uninstall](#appsody-operator-uninstall)	 - Uninstall the Appsody Operator from the configured Kubernetes cluster
+
+## appsody operator install
+
+Install the Appsody Operator into the configured Kubernetes cluster
+
+### Synopsis
+
+Install the Appsody Operator into the configured Kubernetes cluster
+
+```
+appsody operator install [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for install
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.appsody/.appsody.yaml)
+      --dryrun              Turns on dry run mode
+  -n, --namespace string    The namespace in which the operator will run. (default "default")
+  -v, --verbose             Turns on debug output and logging to a file in $HOME/.appsody/logs
+  -w, --watchspace string   The namespace which the operator will watch. Use '' for all namespaces. (default "''")
+```
+
+### SEE ALSO
+
+* [appsody operator](#appsody-operator)	 - Install or uninstall the Appsody operator from your Kubernetes cluster.
+
+## appsody operator uninstall
+
+Uninstall the Appsody Operator from the configured Kubernetes cluster
+
+### Synopsis
+
+Uninstall the Appsody Operator from the configured Kubernetes cluster
+
+```
+appsody operator uninstall [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for uninstall
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file (default is $HOME/.appsody/.appsody.yaml)
+      --dryrun              Turns on dry run mode
+  -n, --namespace string    The namespace in which the operator will run. (default "default")
+  -v, --verbose             Turns on debug output and logging to a file in $HOME/.appsody/logs
+  -w, --watchspace string   The namespace which the operator will watch. Use '' for all namespaces. (default "''")
+```
+
+### SEE ALSO
+
+* [appsody operator](#appsody-operator)	 - Install or uninstall the Appsody operator from your Kubernetes cluster.
 
 ## appsody repo
 
@@ -447,12 +583,13 @@ appsody run [flags]
 ### Options
 
 ```
-      --deps-volume string    Docker volume to use for dependencies. Mounts to APPSODY_DEPS dir. (default "my-project-deps")
-  -h, --help                  help for run
-      --name string           Assign a name to your development container. (default "my-project-dev")
-      --network string        Specify the network for docker to use.
-  -p, --publish stringArray   Publish the container's ports to the host. The stack's exposed ports will always be published, but you can publish addition ports or override the host ports with this option.
-  -P, --publish-all           Publish all exposed ports to random ports
+      --deps-volume string      Docker volume to use for dependencies. Mounts to APPSODY_DEPS dir. (default "my-project-deps")
+      --docker-options string   Specify the docker options to use.  Value must be in "".
+  -h, --help                    help for run
+      --name string             Assign a name to your development container. (default "my-project-dev")
+      --network string          Specify the network for docker to use.
+  -p, --publish stringArray     Publish the container's ports to the host. The stack's exposed ports will always be published, but you can publish addition ports or override the host ports with this option.
+  -P, --publish-all             Publish all exposed ports to random ports
 ```
 
 ### Options inherited from parent commands
@@ -517,12 +654,13 @@ appsody test [flags]
 ### Options
 
 ```
-      --deps-volume string    Docker volume to use for dependencies. Mounts to APPSODY_DEPS dir. (default "my-project-deps")
-  -h, --help                  help for test
-      --name string           Assign a name to your development container. (default "my-project-dev")
-      --network string        Specify the network for docker to use.
-  -p, --publish stringArray   Publish the container's ports to the host. The stack's exposed ports will always be published, but you can publish addition ports or override the host ports with this option.
-  -P, --publish-all           Publish all exposed ports to random ports
+      --deps-volume string      Docker volume to use for dependencies. Mounts to APPSODY_DEPS dir. (default "my-project-deps")
+      --docker-options string   Specify the docker options to use.  Value must be in "".
+  -h, --help                    help for test
+      --name string             Assign a name to your development container. (default "my-project-dev")
+      --network string          Specify the network for docker to use.
+  -p, --publish stringArray     Publish the container's ports to the host. The stack's exposed ports will always be published, but you can publish addition ports or override the host ports with this option.
+  -P, --publish-all             Publish all exposed ports to random ports
 ```
 
 ### Options inherited from parent commands

--- a/content/docs/using-appsody/cli-commands.md
+++ b/content/docs/using-appsody/cli-commands.md
@@ -154,7 +154,7 @@ Build and deploy your Appsody project to your Kubernetes cluster
 ### Synopsis
 
 This command extracts the code from your project, builds a local Docker image for deployment,
-generates a deployment manifest (yaml) file if one is not present, and uses it to deploy your image to Kubernetes.
+generates a deployment manifest (yaml) file if one is not present, and uses it to deploy your image to Kubernetes or Knative.
 
 ```
 appsody deploy [flags]


### PR DESCRIPTION
This updates the cli-commands.md file for release 0.4.0
We will fix the version name on the branch in next weeks release btw.

This was tested with gatsby develop.
Any edits will be made manually if changes are requested.