### PR TITLE
docs: remove mention of .appsody-config file

### DIFF
--- a/content/docs/stacks/build-and-test.md
+++ b/content/docs/stacks/build-and-test.md
@@ -74,7 +74,7 @@ Local appsody operations will also be performed against already pulled or rebuil
 
 ## Associating a template with a specific stack image
 
-For an alreading initialized project:
+For a project that has already been initialized:
 
 1. Update the contents of `.appsody-config.yaml`
 

--- a/content/docs/stacks/create.md
+++ b/content/docs/stacks/create.md
@@ -35,11 +35,6 @@ Templates provide an initial application to enable developers to get started wit
 
 All templates should be created within `/templates`. Every template is contained within its own directory, `/templates/<template-name>`.
 
-Each template must contain `appsody-config.yaml` to specify what stack image the template will use. For example:
-```
-stack: <org-name>/<stack-id>
-```
-
 If the stack is intended to be contributed to the  [Appsody stacks repository](https://github.com/appsody/stacks) the stack image should be called `appsody/<stack-name>:<stack-version>`.
 
 ## Building and testing stacks locally

--- a/content/docs/stacks/stack-structure.md
+++ b/content/docs/stacks/stack-structure.md
@@ -8,6 +8,7 @@ my-stack
 ├── README.md
 ├── stack.yaml
 ├── image/
+|   ├── LICENSE
 |   ├── project/
 |   |   └── Dockerfile
 │   └── Dockerfile-stack
@@ -32,6 +33,9 @@ default-template: my-template # name of default template
 
 ## Stack Image
 Appsody application stacks are provided to developers as a Docker image and include a pre-configured technology stack ready to start application development. It also has mechanisms to control which aspects can and cannot be overridden by the developer.
+
+### LICENSE
+The image directory must include a Apache 2.0 License file.
 
 ### Project directory:
 The project folder should contain a production [Dockerfile](#Dockerfile) for your application and the project you are going to contribute as a content provider.

--- a/content/docs/stacks/stack-structure.md
+++ b/content/docs/stacks/stack-structure.md
@@ -35,7 +35,7 @@ default-template: my-template # name of default template
 Appsody application stacks are provided to developers as a Docker image and include a pre-configured technology stack ready to start application development. It also has mechanisms to control which aspects can and cannot be overridden by the developer.
 
 ### LICENSE
-The image directory must include a Apache 2.0 License file.
+The image directory must include a license file.
 
 ### Project directory:
 The project folder should contain a production [Dockerfile](#Dockerfile) for your application and the project you are going to contribute as a content provider.


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [ ] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
<!-- Write a brief description of the changes introduced by this PR -->
- This PR removes the mentioning of the .appsody-config file during template creation. 
- Fixes some wording. 
- Adds LICENSE file to the file structure

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #32, Related to #54, etc.
-->
fixes: https://github.com/appsody/website/issues/202