### PR TITLE
Add environment variable page to sidebar

### DIFF
--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -27,6 +27,8 @@
       path: /docs/stacks/modify
     - title: Stack Structure
       path: /docs/stacks/stack-structure
+    - title: Stack Environment Variables
+      path: /docs/stacks/environment-variables
     - title: Building and Testing Stacks
       path: /docs/stacks/build-and-test
 - items:


### PR DESCRIPTION
Make the stack environment variable page easier to find, by adding it to the sidebar.

Fixes #221