### PR TITLE
Clarify dependency example in stack-structure be removing extraneous line

### DIFF
--- a/content/docs/stacks/stack-structure.md
+++ b/content/docs/stacks/stack-structure.md
@@ -95,7 +95,6 @@ For efficiency, these only need to be installed when the image is launched. Henc
    ```bash
    RUN pipenv lock -r > requirements.txt
    RUN python -m pip install -r requirements.txt -t /project/deps
-   RUN python -m pip install ptvsd -t /project/deps
    ```
 
 2. Dependencies added by the developer for their application  


### PR DESCRIPTION
We don't need this extra part of the dependency example - less is more when you are learning!

Fixes #224 