### PR TITLE
Improve visibility of stack-structure doc

### DIFF
--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -21,12 +21,12 @@
   items:
     - title: Stacks Overview
       path: /docs/stacks/stacks-overview
+    - title: Stack Structure
+      path: /docs/stacks/stack-structure
     - title: Creating Stacks
       path: /docs/stacks/create
     - title: Modifying Stacks
       path: /docs/stacks/modify
-    - title: Stack Structure
-      path: /docs/stacks/stack-structure
     - title: Stack Variables
       path: /docs/stacks/environment-variables
     - title: Building and Testing Stacks

--- a/content/docs/stacks/stacks-overview.md
+++ b/content/docs/stacks/stacks-overview.md
@@ -28,6 +28,11 @@ To find a list of existing stacks that are available to you:
 
 For information on Appsody local development go [here](/docs/using-appsody/local-development.md).
 
+## Learn about stack operation and structure
+Stacks provide support for all phases of development and deployment. To do this, they need to adhere to a specific structure.
+
+To learn more about this, go to [stack structure](/docs/stacks/stack-structure.md).
+
 ## Modifying existing stacks
 You might want to modify an existing stack to suit your development needs, for example you might want to use a different library or runtime version.
 


### PR DESCRIPTION
This logically probably sits below the "Stack Overview" item in the sidebar, and should also be referenced from the overview.

Fixes: #223 