### PR TITLE
add URLs for official stacks

### DIFF
--- a/content/docs/stacks/stacks-overview.md
+++ b/content/docs/stacks/stacks-overview.md
@@ -19,17 +19,17 @@ Stacks are categorized as either `stable`, `incubator` or `experimental` dependi
 
 - `experimental/`: Experimental stacks are not being actively been worked on and may not fulfill the requirements of an Appsody stack. These can be used for trying out specific capabilities or proof of concept work.
 
-### Official Appsody Stacks
+### Official Appsody Repositories
 
-Below are the URLs for official Appsody releases.
+Below are the URLs for official Appsody repository releases.
 
-| Stack | URL |
+| Repository | URL |
 | ----- | --- |
-| `stable` | TBD |
+| `stable` | `https://github.com/appsody/stacks/releases/latest/download/stable-index.yaml` |
 | `incubator` | `https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml` |
 | `experimental` | `https://github.com/appsody/stacks/releases/latest/download/experimental-index.yaml` |
 
-By default, Appsody comes with the `incubator` stack. Other stacks can be added, to add the `experimental` stack run the following:
+By default, Appsody comes with the `incubator` and `experimental` repositories. Other repositories can be added by running the `repo add` command, an example is shown below:
 
 ```bash
 appsody repo add experimental https://github.com/appsody/stacks/releases/latest/download/experimental-index.yaml

--- a/content/docs/stacks/stacks-overview.md
+++ b/content/docs/stacks/stacks-overview.md
@@ -23,17 +23,13 @@ Stacks are categorized as either `stable`, `incubator` or `experimental` dependi
 
 Below are the URLs for official Appsody repository releases.
 
-| Repository | URL |
-| ----- | --- |
-| `stable` | `https://github.com/appsody/stacks/releases/latest/download/stable-index.yaml` |
-| `incubator` | `https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml` |
+| Repository     | URL                                                                                  |
+| -------------- | ------------------------------------------------------------------------------------ |
+| `stable`       | `https://github.com/appsody/stacks/releases/latest/download/stable-index.yaml`       |
+| `incubator`    | `https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml`    |
 | `experimental` | `https://github.com/appsody/stacks/releases/latest/download/experimental-index.yaml` |
 
-By default, Appsody comes with the `incubator` and `experimental` repositories. Other repositories can be added by running the `repo add` command, an example is shown below:
-
-```bash
-appsody repo add experimental https://github.com/appsody/stacks/releases/latest/download/experimental-index.yaml
-```
+By default, Appsody comes with the `incubator` and `experimental` repositories. Other repositories can be added by running the [`appsody repo add`](https://appsody.dev/docs/using-appsody/cli-commands/#appsody-repo-add) command.
 
 ## Getting started
 Follow our [Quick Start Guide](/content/docs/getting-started/quick-start.md) to get you up and running with Appsody.

--- a/content/docs/stacks/stacks-overview.md
+++ b/content/docs/stacks/stacks-overview.md
@@ -19,6 +19,22 @@ Stacks are categorized as either `stable`, `incubator` or `experimental` dependi
 
 - `experimental/`: Experimental stacks are not being actively been worked on and may not fulfill the requirements of an Appsody stack. These can be used for trying out specific capabilities or proof of concept work.
 
+### Official Appsody Stacks
+
+Below are the URLs for official Appsody releases.
+
+| Stack | URL |
+| ----- | --- |
+| `stable` | TBD |
+| `incubator` | `https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml` |
+| `experimental` | `https://github.com/appsody/stacks/releases/latest/download/experimental-index.yaml` |
+
+By default, Appsody comes with the `incubator` stack. Other stacks can be added, to add the `experimental` stack run the following:
+
+```bash
+appsody repo add experimental https://github.com/appsody/stacks/releases/latest/download/experimental-index.yaml
+```
+
 ## Getting started
 Follow our [Quick Start Guide](/content/docs/getting-started/quick-start.md) to get you up and running with Appsody.
 


### PR DESCRIPTION
## Description
This PR adds a table to the [Stack Overview](https://appsody.dev/docs/stacks/stacks-overview/) page of the Appsody docs. The table shows URLs of the official Appsody released stacks that can be added to the Appsody CLI. By default the Appsody CLI only sets up the incubator stack, there is no mention of the experimental stack URL. With [82 releases](https://github.com/appsody/stacks/releases) in the Appsody repo itself a more obvious way to add/remove official repos should be surfaced in the docs.

The `Stack Overview` page felt like the right spot for this information, but it could easily have gone in [Local Development](https://appsody.dev/docs/using-appsody/local-development). I'm happy to make any changes the reviewers suggest.

## Related Issues

Fixes: #285 