### PR TITLE
nodejs-express: rename template

### DIFF
--- a/content/docs/stacks/build-and-test.md
+++ b/content/docs/stacks/build-and-test.md
@@ -29,10 +29,10 @@ From the base directory:
     appsody repo add my-repo-incubator file://$PWD/ci/assets/incubator-index-local.yaml
     ```
 
-1. Check the built stack has been added in that repository by running `appsody list my-repo-incubator`. Here is an example of the output you should get: 
+1. Check the built stack has been added in that repository by running `appsody list my-repo-incubator`. Here is an example of the output you should get:
     ```
-    REPO            	ID            	VERSION  	TEMPLATES        	DESCRIPTION                      
-    my-repo-incubator	nodejs-express	0.2.5    	*simple, skaffold	Express web framework for Node.js
+    REPO            	ID            	VERSION  	TEMPLATES        	DESCRIPTION
+    my-repo-incubator	nodejs-express	0.2.5    	*simple, scaffold	Express web framework for Node.js
     ```
 
 1. Set an environment variable to use locally created images:
@@ -59,8 +59,8 @@ To build your stack image locally follow the below steps:
     docker build -t <org-name>/<stack-id>:<tag> -f Dockerfile-stack .
     ```
 
-    You now have access to the stack image to use and test locally. 
-    
+    You now have access to the stack image to use and test locally.
+
     **Note:** The local image should be tagged with the desired release. The tag value is usually the major and minor version of the stack, e.g. `appsody/nodejs-express:0.2`. If you do not specify the tag value, it will tag it as the latest version, e.g. `appsody/nodejs-express:latest`.
 
 1. Set an environment variable to use locally created image:
@@ -103,5 +103,3 @@ For a project that has already been initialized:
     appsody test
     appsody build
     ```
-
-

--- a/content/docs/using-appsody/initializing-project.md
+++ b/content/docs/using-appsody/initializing-project.md
@@ -4,7 +4,7 @@ title: Initializing Appsody Projects
 
 # Initializing Appsody Projects
 
-The easiest way to initialize an Appsody project is to start a new source code project from a stack template. However, you can also configure an existing source code project to use an appropriate Appsody stack.  
+The easiest way to initialize an Appsody project is to start a new source code project from a stack template. However, you can also configure an existing source code project to use an appropriate Appsody stack.
 
 ## Creating a new project
 
@@ -23,27 +23,27 @@ Here is an example of the output produced by the `appsody list` command:
 ```
 $ appsody list
 
-REPO      	    ID               	        VERSION  	TEMPLATES        	DESCRIPTION                                
+REPO      	    ID               	        VERSION  	TEMPLATES        	DESCRIPTION
 appsodyhub	    java-microprofile	        0.2.6    	*default         	Eclipse MicroProfile using OpenJ9 and Maven
-appsodyhub	    java-spring-boot2	        0.3.2    	*default, kotlin 	Spring Boot using OpenJ9 and Maven         
-appsodyhub	    nodejs           	        0.2.3    	*simple          	Runtime for Node.js applications           
-appsodyhub	    nodejs-express   	        0.2.3    	*simple, skaffold	Express web framework for Node.js          
-appsodyhub	    swift            	        0.1.2    	*simple          	Runtime for Swift applications 
+appsodyhub	    java-spring-boot2	        0.3.2    	*default, kotlin 	Spring Boot using OpenJ9 and Maven
+appsodyhub	    nodejs           	        0.2.3    	*simple          	Runtime for Node.js applications
+appsodyhub	    nodejs-express   	        0.2.3    	*simple, scaffold	Express web framework for Node.js
+appsodyhub	    swift            	        0.1.2    	*simple          	Runtime for Swift applications
 experimental	java-spring-boot2-liberty	0.1.0    	*default 	        Spring Boot using OpenJ9, Maven and OpenLiberty
-experimental	nodejs-functions         	0.1.1    	*simple  	        Serverless runtime for Node.js functions       
-experimental	quarkus                  	0.1.1    	*default 	        Quarkus runtime for running Java applications 
+experimental	nodejs-functions         	0.1.1    	*simple  	        Serverless runtime for Node.js functions
+experimental	quarkus                  	0.1.1    	*default 	        Quarkus runtime for running Java applications
 
 ```
 You can limit the `appsody list` output by specifying a `repository name` as shown below:
 ```
 $ appsody list appsodyhub
 
-REPO      	ID               	VERSION  	TEMPLATES        	DESCRIPTION                                
+REPO      	ID               	VERSION  	TEMPLATES        	DESCRIPTION
 appsodyhub	java-microprofile	0.2.6    	*default         	Eclipse MicroProfile using OpenJ9 and Maven
-appsodyhub	java-spring-boot2	0.3.2    	*default, kotlin 	Spring Boot using OpenJ9 and Maven         
-appsodyhub	nodejs           	0.2.3    	*simple          	Runtime for Node.js applications           
-appsodyhub	nodejs-express   	0.2.3    	*simple, skaffold	Express web framework for Node.js          
-appsodyhub	swift            	0.1.2    	*simple          	Runtime for Swift applications 
+appsodyhub	java-spring-boot2	0.3.2    	*default, kotlin 	Spring Boot using OpenJ9 and Maven
+appsodyhub	nodejs           	0.2.3    	*simple          	Runtime for Node.js applications
+appsodyhub	nodejs-express   	0.2.3    	*simple, scaffold	Express web framework for Node.js
+appsodyhub	swift            	0.1.2    	*simple          	Runtime for Swift applications
 
 ```
 


### PR DESCRIPTION
We have renamed the template published for nodejs-express from 'skaffold' to 'scaffold' so that it uses proper spelling. The updated stack has been release this morning. 

This PR updates doc references to match the change.

Signed-off-by: Neeraj Laad <neeraj.laad@gmail.com>