### PR TITLE
Fix http status 404 for Windows 10 FAQ

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -9,7 +9,7 @@ Welcome to the FAQ. Here you will find a list of common questions and answers al
 ## CLI Issues
 
 ### 1. Does Appsody support Windows Enterprise users?
-Yes, though Docker Desktop may require special settings to access user folders in the host system. In order to ensure Docker has access to those folders, please follow the instructions in the page [Appsody and Docker Desktop on Windows 10](docker-windows-aad.md).
+Yes, though Docker Desktop may require special settings to access user folders in the host system. In order to ensure Docker has access to those folders, please follow the instructions in the page [Appsody and Docker Desktop on Windows 10](/content/docs/docker-windows-aad.md).
 
 For more information on this issue, click [here](https://github.com/appsody/appsody/issues/24).
 


### PR DESCRIPTION
## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
The current FAQ page is returning a page-not-found (http status 404) response when the user clicks on "...please follow the instructions in the page Appsody and Docker Desktop on Windows 10."

## Related Issues
None.