### PR TITLE
fixes: mobile nav overlapping footer

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -54,7 +54,7 @@ const IndexPage = () => (
     <section className="landing-section text-center">
       <h2 className="mb-2">Why Appsody?</h2>
       <div className="container">
-        <div className="row w-100 mx-auto">
+        <div className="row w-100 mx-auto homepage-sections">
           <div className="col m-3 p-4">
             <h3>CLI</h3>
             <p>Intuitive and powerful. The Appsody CLI allows you to connect to a Hub, pull down a stack, and create, build, test and deploy your application.</p>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -340,6 +340,21 @@ footer {
   text-align: center;
 }
 
+@media only screen and (max-width: 767px) {
+  footer {
+    bottom:75px
+  }
+
+  .doc-content {
+    margin-bottom: 75px;;
+  }
+
+  .homepage-sections {
+    margin-bottom: 50px;
+  }
+
+}
+
 #docs footer {
   grid-column-start: 1;
   grid-column-end: 3;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -342,15 +342,15 @@ footer {
 
 @media only screen and (max-width: 767px) {
   footer {
-    bottom:75px
+    bottom: 4em;
   }
 
   .doc-content {
-    margin-bottom: 75px;;
+    margin-bottom: 4em;
   }
 
   .homepage-sections {
-    margin-bottom: 50px;
+    margin-bottom: 3em;
   }
 
 }

--- a/src/styles/mobileNav.module.css
+++ b/src/styles/mobileNav.module.css
@@ -27,7 +27,8 @@
       width: 100%;
       position: fixed;
       bottom: 0;
-      box-shadow: 1px -2.5px 4px var(--dark-grey);
+      /* box-shadow: 1px -2.5px 4px var(--dark-grey); */
+      border-top: 3px solid var(--light-grey);
       background-color: white;
       display: flex;
       justify-content: center;

--- a/src/styles/mobileNav.module.css
+++ b/src/styles/mobileNav.module.css
@@ -27,7 +27,6 @@
       width: 100%;
       position: fixed;
       bottom: 0;
-      /* box-shadow: 1px -2.5px 4px var(--dark-grey); */
       border-top: 3px solid var(--light-grey);
       background-color: white;
       display: flex;

--- a/src/styles/mobileNav.module.css
+++ b/src/styles/mobileNav.module.css
@@ -23,7 +23,7 @@
   @media only screen and (max-width: 767px) {
     .mobile-nav {
       display: block;
-      height: 75px;
+      height: 4em;
       width: 100%;
       position: fixed;
       bottom: 0;


### PR DESCRIPTION
- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
Fixes an issue where the new mobile navigation bar overlaps the footer in mobile mode. Adds some padding for the content of the page too.

## Related Issues
Fixes #325 

![Screenshot 2019-10-29 at 11 56 46](https://user-images.githubusercontent.com/24469095/67765199-77bae280-fa43-11e9-9756-c49232d86fd6.png)
