### PR TITLE
Add safe area to iPhone to avoid home bar overlapping nav menu

### DIFF
--- a/src/styles/mobileNav.module.css
+++ b/src/styles/mobileNav.module.css
@@ -23,7 +23,7 @@
   @media only screen and (max-width: 767px) {
     .mobile-nav {
       display: block;
-      height: 4em;
+      height: 5em + env(safe-area-inset-bottom);
       width: 100%;
       position: fixed;
       bottom: 0;
@@ -33,6 +33,7 @@
       justify-content: center;
       align-items: center;
       z-index: 2;
+      padding-bottom: env(safe-area-inset-bottom);
     }
 
     .mobile-nav a {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
The homebar on newer iPhones requires some safe areas to be used, or else content can scroll too low and be hard to tap. This PR adds that safe area to the bottom menu. The change will only appear on iPhones running iOS 11+ and with a homebar (iPhone X onwards). Makes no changes in Chrome.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #32, Related to #54, etc.
-->
#391