### PR TITLE
Removed reference to controller bind mount

### DIFF
--- a/content/docs/getting-started/installation.md
+++ b/content/docs/getting-started/installation.md
@@ -116,12 +116,12 @@ If you are unsure about which directories are mounted by the stack you are using
 [ibmadmin@naval1 my-project]$ appsody run
 Running development environment...
 Running command: docker[pull appsody/nodejs-express:0.2]
-Running command: docker[run --rm -p 3000:3000 -p 9229:9229 --name my-project-dev -v /home/ibmadmin/appsody/my-project/:/project/user-app -v my-project-deps:/project/user-app/node_modules -v /home/ibmadmin/.appsody/appsody-controller:/.appsody/appsody-controller -t --entrypoint /.appsody/appsody-controller appsody/nodejs-express:0.2 --mode=run]
+Running command: docker[run --rm -p 3000:3000 -p 9229:9229 --name my-project-dev -v /home/ibmadmin/appsody/my-project/:/project/user-app -v my-project-deps:/project/user-app/node_modules -v appsody-controller-0.3.1:/.appsody/appsody-controller -t --entrypoint /.appsody/appsody-controller appsody/nodejs-express:0.2 --mode=run]
 ```
-In the example above, there are two binding mounts:
-* /home/ibmadmin/appsody/my-project/
-* /home/ibmadmin/.appsody/appsody-controller
-
+In the example above, there is one binding mount:
+```
+/home/ibmadmin/appsody/my-project/
+```
 In this case, whitelisting the home directory (`/home/ibmadmin`) would be sufficient.
 
 # Upgrading Appsody


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x ] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [ x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Removed the remaining reference to the controller bind mount - now obsolete.
## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #32, Related to #54, etc.
-->
#393 