### PR TITLE
New styling for inline code blocks (bold, new font)

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -613,10 +613,12 @@ hr {
 }
 
 .doc-content :not(pre)>code {
-    padding: .3em;
-    background-color: var(--light-grey);
     border-radius: .1em;
     color: #000;
+    font-weight: 700;
+    font-family: 'SFMono-Regular', 'Menlo', 'Times New Roman', Times, serif;
+    font-size: 0.9em;
+
 }
 
 .doc-content a {
@@ -666,10 +668,6 @@ blockquote {
 
 blockquote p {
   margin: 0;
-}
-
-.doc-content blockquote p code {
-  background-color: var(--dark-grey);
 }
 
 .docs-header-text {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
Changes the design for inline code blocks to be bold and a different font compared to the current style of being grey boxes, which can be hard to see on some table rows.

## Example
![Screenshot 2019-11-22 at 11 30 20](https://user-images.githubusercontent.com/24469095/69422444-9dbe6480-0d1b-11ea-8b26-0ad76d227e0c.png)
