### PR TITLE
Fixes tips in quickstart to use the new quote styling

### DIFF
--- a/content/docs/getting-started/quick-start.md
+++ b/content/docs/getting-started/quick-start.md
@@ -39,5 +39,5 @@ You are ready to continue developing your application.
 - To enable the debugger, restart the container with `appsody debug`.
 - When you are ready to build a production docker image, run `appsody build`.
 
-**Tip:** You can get more information about all the available commands by running `appsody help [command]` or `appsody <command> --help`.
+> You can get more information about all the available commands by running `appsody help [command]` or `appsody <command> --help`.
 

--- a/content/docs/stacks/modify.md
+++ b/content/docs/stacks/modify.md
@@ -52,7 +52,9 @@ Templates are converted into their values before a stack is packaged. To use tem
 
 **Example usage:**
 
-`This is {{.stack.name}}, running version: {{.stack.version}}.`
+```
+This is {{.stack.name}}, running version: {{.stack.version}}.
+```
 
 > Do not use templating for a readme file.
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
The quickstart guide was using a bold text section for displaying the tip at the bottom of the page. This PR fixes it to use the new block quote style introduced recently.