### PR TITLE
Moved user exectuable code into their own code blocks

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -34,12 +34,19 @@ When you encounter the following error
 
 1. Go to your home directory and open the **repository.yaml** using an editor of your choice.
 
-    - `cd ~/.appsody/repository/` (macOS/Linux)
-    - `cd %HOMEPATH%/.appsody/repository/` (Windows)
-
+    - On macOS/Linux
+        ```
+        cd ~/.appsody/repository/
+        ``` 
+    - On Windows
+        ```
+        cd %HOMEPATH%/.appsody/repository/
+        ``` 
 2. Change the URL for the incubator repository to reference the latest incubator index, which is:
 
-`https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml`
+    ```
+    https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
+    ```
 
 3. Save your changes and try running your command again.
 

--- a/content/docs/stacks/create.md
+++ b/content/docs/stacks/create.md
@@ -15,12 +15,14 @@ You can start by using either the Appsody CLI `appsody stack create` command, or
 ### Using the Appsody CLI
 
 The quickest way to create a new stack is to use the `appsody stack create` command, which creates a new stack by copying an existing stack. By default, the new stack is based on the [sample stack](https://github.com/appsody/stacks/tree/master/samples/sample-stack). For example, to create a new stack named `my-stack`, in a new directory, use this command:
-
-`appsody stack create my-stack`
+```
+appsody stack create my-stack
+```
 
 If you want to use a different stack as the basis for your new stack, use the `copy` flag to specify the stack you want to use as the starting point. You can use `appsody list` to see the available stacks. For example, to create a new stack, called `my-stack`, based on the Node.js Express stack use this command:
-
-`appsody stack create my-stack --copy incubator/nodejs-express`
+```
+appsody stack create my-stack --copy incubator/nodejs-express
+```
 
 ### Using Git clone
 

--- a/content/docs/stacks/package.md
+++ b/content/docs/stacks/package.md
@@ -12,13 +12,21 @@ Alternatively, you can also use the [CI scripts](#packaging-a-stack-locally-usin
 
 ## Packaging a stack locally using the Appsody CLI
 
-Run `appsody stack package` to package your stack locally. Run this command from the base directory of your stack, or specify the path to your stack (e.g. `appsody stack package [path/to/stack]`).
+To package your stack locally, run: 
+```
+appsody stack package
+```
+Run this command from the base directory of your stack, or specify the path to your stack (e.g. `appsody stack package [path/to/stack]`).
 
 This builds the stack container image, creates archives for each template, and adds your stack to the `dev.local` repository in your Appsody configuration.
 
 
 ### Using your packaged stack
-1. Run `appsody repo list` to see the repository named `dev.local`, that points to the generated index.
+1. To see the repository named `dev.local`, that points to the generated index, run:
+    ```
+    appsody repo list
+    ```
+    The output should look something like this:
     ```
     NAME            URL
     *incubator  	https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml                    
@@ -26,15 +34,23 @@ This builds the stack container image, creates archives for each template, and a
     experimental	https://github.com/appsody/stacks/releases/latest/download/experimental-index.yaml
     ```
 
-1. Run `appsody list dev.local` to check the built stack is visible in the `dev.local` repository. Here is an example of the output you should get:
+1. To check the built stack is visible in the `dev.local` repository, run:
+    ```
+    appsody list dev.local
+    ```
+    Here is an example of the output you should get:
     ```
     REPO            	    ID            	VERSION  	TEMPLATES        	DESCRIPTION                      
     dev.local	            <stack-id>	    <version>   *<template>	        <stack-description>
     ```
-1. Create a directory to initialize your project in (e.g. `mkdir my-project`).
-
-1. Navigate to the directory of your new project (e.g. `cd my-project`).
-
+1. Create a directory to initialize your project in, for example:
+    ```
+    mkdir my-project
+    ```
+1. Navigate to the directory of your new project, for example:
+    ```
+    cd my-project
+    ```
 1. Use the Appsody CLI to create new projects using the packaged stack:
     ```
     appsody init dev.local/<stack-id>
@@ -47,16 +63,23 @@ To test your new stack, see [Testing Stacks](/docs/stacks/test).
 To package a stack using CI scripts, clone or copy the `appsody/stacks` Git repository. From the base directory
 
 Run the build script and specify the desired stack as a parameter, for example:
-    ```
-     ./ci/build.sh incubator/<stack-id>
-    ```
+```
+./ci/build.sh incubator/<stack-id>
+```
 
 > If a stack is not specified, all stacks in all repositories are built.
 
 ### Using your packaged stack
-1. A local repository based on the stacks built is added to the repository list. Run ```appsody repo list``` to see this repository named `<repo>-index-local`
+1. A local repository based on the stacks built is added to the repository list. To see the repository named `<repo>-index-local`, run: 
+    ```
+    appsody repo list
+    ```
 
-1. Check the built stack has been added in that repository by running `appsody list <repo>-index-local`. Here is an example of the output you should get:
+1. Check the built stack has been added in that repository by running:
+    ```
+    appsody list <repo>-index-local
+    ```
+    Here is an example of the output you should get:
     ```
     REPO            	    ID            	VERSION  	TEMPLATES        	DESCRIPTION
     incubator-index-local	<stack-id>	    <version>   *<template>	        <stack-description>
@@ -66,9 +89,15 @@ Run the build script and specify the desired stack as a parameter, for example:
     ```
     export APPSODY_PULL_POLICY=IFNOTPRESENT
     ```
-1. Create a directory to initialize your project in (e.g. `mkdir my-project`).
+1. Create a directory to initialize your project in, for example:
+    ```
+    mkdir my-project
+    ```
 
-1. Navigate to the directory of your new project (e.g. `cd my-project`).
+1. Navigate to the directory of your new project, for example:
+    ```
+    cd my-project
+    ```
 
 1. Use the Appsody CLI to create new projects using the packaged stack:
     ```

--- a/content/docs/stacks/publish.md
+++ b/content/docs/stacks/publish.md
@@ -30,7 +30,7 @@ After creating and testing a stack locally, you might want to make the stack ava
 
 ### Publishing a stack using the Appsody CLI
 
-1. If the stack is not already packaged, package it by running the [`appsody stack package` command](/content/docs/using-appsody/cli-commands.md/#appsody-stack-package). Run this command from the base directory of your stack, specifying the namespace for creating the Docker images with. For example, the following command creates Docker images with a namespace of `myproject`.
+1. If the stack is not already packaged, package it by running the [`appsody stack package` command](/content/docs/using-appsody/cli-commands.md/#appsody-stack-package). Run this command from the base directory of your stack, specifying the namespace for creating the Docker images with. For example, the following command creates Docker images with a namespace of `myproject`:
     ```
     appsody stack package --image-namespace myproject
     ```
@@ -41,7 +41,7 @@ After creating and testing a stack locally, you might want to make the stack ava
 
 3. Upload the template archives to a suitable web hosting service.
 
-4. Generate a repository index for the stack, which will point to the template archive files that you uploaded to the web hosting service. To generate the index, run the [`appsody stack add-to-repo` command](/content/docs/using-appsody/cli-commands.md/#appsody-stack-addtorepo)  from the base directory of your stack, specifying the repository name and the base URL to use. For example: 
+4. Generate a repository index for the stack, which points to the template archive files that you uploaded to the web hosting service. To generate the index, run the [`appsody stack add-to-repo` command](/content/docs/using-appsody/cli-commands.md/#appsody-stack-addtorepo) from the base directory of your stack, specifying the repository name and the base URL to use. For example: 
     ```
     appsody stack add-to-repo myrepository --release-url https://github.com/myorg/myrepository/releases/latest/download/
     ```

--- a/content/docs/stacks/publish.md
+++ b/content/docs/stacks/publish.md
@@ -30,7 +30,10 @@ After creating and testing a stack locally, you might want to make the stack ava
 
 ### Publishing a stack using the Appsody CLI
 
-1. If the stack is not already packaged, package it by running the [`appsody stack package` command](/content/docs/using-appsody/cli-commands.md/#appsody-stack-package). Run this command from the base directory of your stack, specifying the namespace for creating the Docker images with. For example: `appsody stack package --image-namespace myproject` creates Docker images with a namespace of `myproject`.
+1. If the stack is not already packaged, package it by running the [`appsody stack package` command](/content/docs/using-appsody/cli-commands.md/#appsody-stack-package). Run this command from the base directory of your stack, specifying the namespace for creating the Docker images with. For example, the following command creates Docker images with a namespace of `myproject`.
+    ```
+    appsody stack package --image-namespace myproject
+    ```
 
     This command builds the stack container image, creates archives for each template, and adds your stack to the `dev.local` repository in your Appsody configuration.
 
@@ -38,7 +41,10 @@ After creating and testing a stack locally, you might want to make the stack ava
 
 3. Upload the template archives to a suitable web hosting service.
 
-4. Generate a repository index for the stack, which will point to the template archive files that you uploaded to the web hosting service. To generate the index, run the [`appsody stack add-to-repo` command](/content/docs/using-appsody/cli-commands.md/#appsody-stack-addtorepo)  from the base directory of your stack, specifying the repository name and the base URL to use. For example: `appsody stack add-to-repo myrepository --release-url https://github.com/myorg/myrepository/releases/latest/download/`
+4. Generate a repository index for the stack, which will point to the template archive files that you uploaded to the web hosting service. To generate the index, run the [`appsody stack add-to-repo` command](/content/docs/using-appsody/cli-commands.md/#appsody-stack-addtorepo)  from the base directory of your stack, specifying the repository name and the base URL to use. For example: 
+    ```
+    appsody stack add-to-repo myrepository --release-url https://github.com/myorg/myrepository/releases/latest/download/
+    ```
 
     This command creates (or updates) a repository index file using the specified  `--release-url` as the base URL for referencing the template archives. The index file is determined from the repository name (`myrepository-index.yaml` in this example), and is created in the `.appsody/stacks/dev.local` directory
 
@@ -49,7 +55,10 @@ You can now provide the URL to the hosted repository index file to other Appsody
 ### Publishing a stack using CI scripts
 
 1. Clone or copy the `appsody/stacks` Git repository to obtain the CI scripts.
-2. Create a new repository directory, within the base directory of the Git repository, to contain the stack to be published. For example, `mkdir ./myrepository`
+2. Create a new repository directory, within the base directory of the Git repository, to contain the stack to be published. For example: 
+    ```
+    mkdir ./myrepository
+    ```
 3. Copy or create your stack into this new directory.
 4. Use environment variables to override default settings that are used by the build script, for example the namespace to use for the Docker images, and the URL to use to reference the template archive files. The main variables to override are:
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
-    "deploy": "gatsby clean && gatsby build --prefix-paths && gh-pages -d public -o staging",
+    "deploy": "gatsby clean && gatsby build --prefix-paths && gh-pages -d public",
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
-    "deploy": "gatsby clean && gatsby build --prefix-paths && gh-pages -d public",
+    "deploy": "gatsby clean && gatsby build --prefix-paths && gh-pages -d public -o staging",
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
If a user is expected to copy some code into their terminal, the code should not be inline with the rest of the normal text. Referencing a command can stay inline though, this PR just moved the code that a user is expected to put into their terminal onto their own lines to they get the code block styling.

## Related Issues
#409 