### PR TITLE
 Glossary page (No MDX support)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -157,5 +157,30 @@ gatsby serve
 
 3. Access the website on http://localhost:9000 and complete any visual checks.
 
+
+## Adding definitions to the Glossary page
+
+If you feel a term would benefit from being defined, the Glossary is the perfect place to do so! The file is located inside the docs directory, as `glossary.md`.
+
+In order to render correctly, definitions need to be written in the following way:
+
+```
+>### Term Name
+This is where you would write a brief description explaining the term.  
+Feel free to include links, images, and inline code snippets. Code blocks are supported.
+```
+
+For a new line, end the sentence with two spaces before pressing the enter key.
+
+For an empty line, insert an empty character (`&thinsp;`) with two spaces following it.
+
+The large letters, marking the letter of the alphabet the definitions belong to, are simply written with the following syntax:
+
+```
+## Letter
+```
+
+> The glossary is not self-organising, so try to add definitions in their correct place alphabetically.
+
 ## Need help?
 If you have a question that you can't find an answer to, we want to hear from you. Reach out to the community for assistance on [Slack](https://appsody-slack.eu-gb.mybluemix.net/).

--- a/content/docs/glossary.md
+++ b/content/docs/glossary.md
@@ -1,0 +1,28 @@
+---
+title: Glossary
+---
+
+# Glossary
+Learn about terms and definitions that are related to the Appsody project.
+
+## A
+
+>### Appsody CLI
+The Appsody command-line interface supports the full application development lifecycle; creating stacks, creating applications based on stacks, testing and debugging your applications, and deployment to Kubernetes.  
+
+## D
+
+>### Dockerfile
+Dockerfile combines your application and the stack to build a production image, ready for deployment.  
+&thinsp;  
+For more information on Dockerfiles see the official [Docker documentation](https://docs.docker.com/engine/reference/builder).
+
+>### Dockerfile-stack
+Dockerfile-stack is a Dockerfile that builds a stack container image used during development.  
+&thinsp;  
+For more information on Dockerfiles see the official [Docker documentation](https://docs.docker.com/engine/reference/builder).
+
+## P
+
+>### Project Template
+Project templates provide a starting point, typically a ‘Hello World’ application, for application development. Like other components within an Appsody stack, you can customize project templates and share them across teams.

--- a/content/docs/sidebar.yaml
+++ b/content/docs/sidebar.yaml
@@ -36,3 +36,5 @@
       path: /docs/stacks/environment-variables
 - title: FAQ
   path: /docs/faq
+- title: Glossary
+  path: /docs/glossary

--- a/src/components/doc.js
+++ b/src/components/doc.js
@@ -2,9 +2,15 @@ import React from "react";
 
 class Doc extends React.Component {
     render() {
-        return (
-            <div id="documents-window" className="doc-content" dangerouslySetInnerHTML={{ __html: this.props.html }} />
-        )
+        if(this.props.title === "Glossary") {
+            return (
+                <div id="documents-window" className="glossary-content" dangerouslySetInnerHTML={{ __html: this.props.html }} />
+            )
+        } else {
+            return (
+                <div id="documents-window" className="doc-content" dangerouslySetInnerHTML={{ __html: this.props.html }} />
+            )
+        }
     }
 
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -718,7 +718,7 @@ blockquote p {
   max-width: 2000px;
 }
 
-.glossay-content, h1 {
+.glossary-content h1 {
   color: var(--colour-scheme-1);
   font-weight: 600;
   font-size: 2.1em;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -410,6 +410,16 @@ footer a:hover {
   margin-bottom: 0px;
 }
 
+.sidebar-heading-link a{
+  color: black;
+  font-size: 1.3rem;
+  margin-top: 1.4rem;
+}
+
+#documents-window {
+  transition: 0.5s;
+}
+
 .accordion-dropdown:hover {
   filter: invert(33%) sepia(54%) saturate(1628%) hue-rotate(295deg) brightness(86%) contrast(81%);
 }
@@ -698,6 +708,75 @@ blockquote p {
   }
 }
 
-#documents-window {
-  transition: 0.5s;
+/* Glossary Page Styling */
+
+.glossary-content {
+  padding-left: 23rem;
+  margin-top: 5rem;
+  padding-bottom: 4rem;
+  padding-right: 2em;
+  max-width: 2000px;
+}
+
+.glossay-content, h1 {
+  color: var(--colour-scheme-1);
+  font-weight: 600;
+  font-size: 2.1em;
+  margin-bottom: 1rem;
+}
+
+.glossary-content blockquote {
+  padding: 0.6em 1.5em 0.6em 1.5em;
+  margin: 1rem 0 2rem 0;
+  border-left: 4px solid var(--colour-scheme-1);
+  border-radius: 0 0 1.1rem 0;
+  color: #000;
+  max-width: 1200px;
+  background: white;
+}
+
+.glossary-content a {
+  color: var(--colour-scheme-1);
+  font-weight: 600;
+}
+
+.glossary-content :not(pre)>code {
+    border-radius: .1em;
+    color: #000;
+    font-weight: 700;
+    font-family: 'SFMono-Regular', 'Menlo', 'Times New Roman', Times, serif;
+    font-size: 0.95rem;
+    margin-left: 0.1em;
+    margin: 0 5px;
+}
+
+.glossary-content h2 {
+  font-weight: 600;
+  font-size: 2.0em;
+  line-height: 1.5em;
+  margin-bottom: -0.4em;
+  margin-left: -3px;
+  margin-top: 1em;
+}
+
+.glossary-content h3 {
+  margin-bottom: 0.5em;
+  padding: 0em;
+  text-align: left;
+  font-weight: bold !important;
+  font-size: 1.4rem;
+}
+
+@media only screen and (max-width: 767px) {
+  .glossary-content {
+    margin-bottom: 3em;
+    padding: 2em;
+    padding-bottom: 4em;
+    padding-top: 0;
+  }
+
+  .glossary-content h2 {
+    margin-top: 0;
+  }
+
 }

--- a/src/templates/docTemplate.js
+++ b/src/templates/docTemplate.js
@@ -21,7 +21,7 @@ export default function Template({
       <DesktopSidebarOpenButton/>
       <SidebarExtender />
       <DesktopSidebarCloseButton/>
-      <Doc html={html}/>
+      <Doc html={html} title={title}/>
     </Layout>
   )
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
Adds a glossary page to the site without MDX support, so the website will work as it always has and we can merge the Glossary page in without needing to fix the CLI reference page breaking React components with unclosed HTML tags (https://github.com/appsody/appsody/issues/761).

## Related Issues
#282 #272 