### PR TITLE
Make dividers look correct in dark mode

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1213,4 +1213,8 @@ input.checkbox-item {
   .docs-header-pink {
     color: var(--colour-scheme-1);
   }
+
+  hr {
+    border-top: 1px solid rgba(255, 255, 255,.1);
+  }
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
Dividers stayed dark in dark mode and therefore were too hard to see, this PR changes them to make them the correct colour in dark mode.
