### PR TITLE
Remove knative deploy option because it no longer exists

### DIFF
--- a/content/docs/using-appsody/building-and-deploying.md
+++ b/content/docs/using-appsody/building-and-deploying.md
@@ -48,9 +48,7 @@ There are many options to deploy your Appsody applications to a Kubernetes clust
 - If you are testing your app on a locally installed cluster, using `appsody deploy` is your best bet
 - If you intend to have your app deployed on a shared cluster for integration testing or production, you are probably going to rely on CI/CD pipelines, and have the app built and deployed from its source.
 
-The `appsody deploy` command provides a way for you to deploy your application directly to a Kubernetes cluster. The deployment may occur in one of two different ways, depending on how the stack you are using is configured:
-- If the stack contains a deployment manifest that can be consumed by the [Appsody operator](https://operatorhub.io/operator/appsody-operator), `appsody deploy` will install the operator, if necessary, and deploy your application to the cluster using that deployment manifest.
-- If the stack you are using is not equipped with the manifest for the Appsody operator, `appsody deploy` attempts to install your app as a Knative serving service.
+The `appsody deploy` command provides a way for you to deploy your application directly to a Kubernetes cluster. The stack contains a deployment manifest that can be consumed by the [Appsody operator](https://operatorhub.io/operator/appsody-operator). `appsody deploy` will install the operator, if necessary, and deploy your application to the cluster using that deployment manifest.
 
 If you want to deploy your application without rebuilding the application image, or modifying the deployment manifest, you can run
 ```


### PR DESCRIPTION
This functionality was removed in commit https://github.com/appsody/appsody/commit/41ff13d15f5104dede1ee13a20307bfaa089b42f

<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [ ] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [ ] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #32, Related to #54, etc.
-->
#issue-number