### PR TITLE
Add operator and controller to glossary.md

### DIFF
--- a/content/docs/glossary.md
+++ b/content/docs/glossary.md
@@ -10,6 +10,12 @@ Learn about terms and definitions that are related to the Appsody project.
 >### Appsody CLI
 The Appsody command-line interface supports the full application development lifecycle; creating stacks, creating applications based on stacks, testing and debugging your applications, and deployment to Kubernetes.  
 
+>### Appsody controller
+The controller manages a running application inside the Appsody development container. It monitors file changes in the application source and provides live updates to the application running in the container.  
+
+>### Appsody operator
+The operator manages the deployment of applications that are developed using Appsody to Kubernetes environments.  
+
 ## D
 
 >### Dockerfile


### PR DESCRIPTION
Add Appsody controller and Appsody operator definitions to the Glossary.

<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
Adds two more Appsody terms to the Glossary.

## Related Issues
Issue #272
