### PR TITLE
Document image-registry flag in publishing stacks doc

### DIFF
--- a/content/docs/stacks/publish.md
+++ b/content/docs/stacks/publish.md
@@ -57,7 +57,7 @@ The easiest way to publish a stack is to use the Appsody CLI, however, you can u
         ./create_codewind_index.py -f /assets
         ```
 
-6. Upload the generated repository index file to the web hosting service.
+6. Upload the generated repository index files (`yaml` and `json`) to the web hosting service.
 
 You can now provide the URL to the hosted repository index file to other Appsody users, who can add it to their Appsody repository list then initialise a project using your stack.
 

--- a/content/docs/stacks/publish.md
+++ b/content/docs/stacks/publish.md
@@ -31,7 +31,7 @@ The easiest way to publish a stack is to use the Appsody CLI, however, you can u
     appsody stack package --image-namespace myproject --image-registry myregistry.io
     ```
 
-2. Push the stack container image to a Docker registry, such as [docker.io](https://docker.io).
+2. Push the stack container image to the appropriate Docker registry, such as [docker.io](https://docker.io) or `myregistry.io`.
 
 3. Upload the source code and template archives to a suitable web hosting service, such as the [Releases](https://help.github.com/en/github/administering-a-repository/creating-releases) section of a GitHub repo.
 

--- a/content/docs/stacks/publish.md
+++ b/content/docs/stacks/publish.md
@@ -26,6 +26,11 @@ The easiest way to publish a stack is to use the Appsody CLI, however, you can u
 
     This command builds the stack container image, creates archives for your source code and each template, and adds your stack to the `dev.local` repository in your Appsody configuration.
 
+    If you want to publish your Docker images to a non-default image registry, such as `docker.io`, you can specify the registry to use with the `--image-registry` flag:
+    ```
+    appsody stack package --image-namespace myproject --image-registry docker.io
+    ```
+
 2. Push the stack container image to a Docker registry, such as [docker.io](https://docker.io).
 
 3. Upload the source code and template archives to a suitable web hosting service, such as the [Releases](https://help.github.com/en/github/administering-a-repository/creating-releases) section of a GitHub repo.

--- a/content/docs/stacks/publish.md
+++ b/content/docs/stacks/publish.md
@@ -26,9 +26,9 @@ The easiest way to publish a stack is to use the Appsody CLI, however, you can u
 
     This command builds the stack container image, creates archives for your source code and each template, and adds your stack to the `dev.local` repository in your Appsody configuration.
 
-    If you want to publish your Docker images to a non-default image registry, such as `docker.io`, you can specify the registry to use with the `--image-registry` flag:
+    If you want to publish your Docker images to a non-default image registry, such as `myregistry.io`, you can specify the registry to use with the `--image-registry` flag:
     ```
-    appsody stack package --image-namespace myproject --image-registry docker.io
+    appsody stack package --image-namespace myproject --image-registry myregistry.io
     ```
 
 2. Push the stack container image to a Docker registry, such as [docker.io](https://docker.io).


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
The example in the publishing stacks documentation doesn't mention the `image-registry` flag so users will end up with their stack images in `dev.local` which they might not want. 

## Related Issues
Fixes #509