### PR TITLE
Update docs to match Tekton example

### DIFF
--- a/content/docs/using-appsody/building-and-deploying.md
+++ b/content/docs/using-appsody/building-and-deploying.md
@@ -259,12 +259,4 @@ Most likely, the deployment of apps created with the appsody CLI is going to occ
 
 As a developer, you develop your app using the appsody CLI, and when you are ready to deploy, you push your code to a repo or create a pull request on GitHub.
 
-This [example](https://github.com/appsody/tekton-example) shows you how to use Tekton pipelines to deploy your app as a Knative Serving service to a Kubernetes cluster.
-
-The following pre-requisites are required to run the example pipeline:
-
-- You must have developed a project with the appsody CLI, and you must have checked your project into a GitHub repository.
-- Your Kubernetes cluster must be configured to run Tekton pipelines (see [Installing Tekton Pipelines](https://github.com/tektoncd/pipeline/blob/master/docs/install.md)).
-- Your project must include a deployment manifest called `app-deploy.yaml`, which is a current pre-requisite if you want to run the pipeline with minimal changes. A quick way to obtain such a manifest is to run the `appsody deploy --generate-only` command, and then check the `app-deploy.yaml` file into your source code repository.
-
-More details on running the Tekton pipeline example for Appsody can be found in the repo [readme file] (https://github.com/appsody/tekton-example/blob/master/README.md)
+This [example](https://github.com/appsody/tekton-example) shows you how to use Tekton pipelines to deploy your app to a Kubernetes cluster. More details on running the Tekton pipeline example for Appsody can be found in the repo [readme file] (https://github.com/appsody/tekton-example/blob/master/README.md).


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
Fixes the issue https://github.com/appsody/appsody/issues/887.

The Tekton pipeline example doesn't use Knative serving any more.  Plus the prerequisites are all listed in tekton-example README, plus `appsody deploy --generate-only` has been replaced (as suggested) with `appsody build`.