### PR TITLE
remove references of 'head over to Appsody' from blogs

### DIFF
--- a/content/blogs/AutumnUpdate.md
+++ b/content/blogs/AutumnUpdate.md
@@ -9,7 +9,7 @@ imagePath: "http://localhost:8000/static/e05283c91c0cc09f39645b4b283a68a7/8dcf2/
 
 ![Autumn](./resources/autumn.jpeg)
 
-It’s been a busy couple of months since we publicly launched as an open source project, full of fixes, features and (cloud) functions. If you’ve not tried Appsody yet, head over to [appsody.dev](https://appsody.dev), create cloud native applications and live your best life.
+It’s been a busy couple of months since we publicly launched as an open source project, full of fixes, features and (cloud) functions. If you’ve not tried Appsody yet, head over to our docs, create cloud native applications and live your best life.
 
 ## Doubling the number of Stacks
 

--- a/content/blogs/BohemianAppsody.md
+++ b/content/blogs/BohemianAppsody.md
@@ -15,7 +15,7 @@ This was the challenge I was faced with, and naturally — given our project bei
 
 I’m not claiming it’s 100% true to a developer’s experience, or that everyone in the world is using WebSphere Network Deployment, the flow isn’t perfect, etc etc, but hey — it was fun to create, and I hope you enjoy it as well.
 
-Please come check out the project at [https://appsody.dev](https://appsody.dev), follow us on [Twitter](https://twitter.com/appsodydev), and star our [GitHub](https://github.com/appsody) repos if you like what you see!
+Please come check out our project, follow us on [Twitter](https://twitter.com/appsodydev), and star our [GitHub](https://github.com/appsody) repos if you like what you see!
 
 ## Bohemian Appsody
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Removed references of "head over to Appsody" from blogs as we have migrated blogs to be directly on the website

