### PR TITLE
Add reference to appsody buildah image under tekton section

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -104,7 +104,7 @@ chcon -Rt svirt_sandbox_file_t </path/to/volume>
 ```
 You might need to run this command multiple times to whitelist different paths, depending on your setup, and on the mount points of the specific stack you are using.
 
-### 9. Can I use Appsody without Docker?
+### 9. Can I use Appsody without Docker? 
 
 Appsody lists Docker as a prerequisite for creating and running applications and stacks. However, certain Appsody operations like building an application, or packaging a stack can also be done with Buildah. Using Buildah is useful in environments where Docker is not available, for example, in Tekton pipelines or other Kubernetes environments. To use Buildah with Appsody, instead of Docker, add the `--buildah` flag to the following Appsody commands:
 ```

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -103,3 +103,15 @@ You can exempt the folders that are mounted by the stacks that you are using, wi
 chcon -Rt svirt_sandbox_file_t </path/to/volume>
 ```
 You might need to run this command multiple times to whitelist different paths, depending on your setup, and on the mount points of the specific stack you are using.
+
+### 9. Can I use Appsody without Docker?
+
+Appsody lists Docker as a prerequisite for creating and running applications and stacks. However, certain Appsody operations like building an application, or packaging a stack can also be done with Buildah. Using Buildah is useful in environments where Docker is not available, for example, in Tekton pipelines or other Kubernetes environments. To use Buildah with Appsody, instead of Docker, add the `--buildah` flag to the following Appsody commands:
+```
+appsody stack package
+appsody extract
+appsody build
+appsody deploy
+```
+
+For convenience, there is also a container image `appsody-buildah` that includes the current version of the Appsody CLI and the version of buildah that is used by Appsody. If you would like to modify this image to fit your own purposes, you can find the Dockerfile in the [appsody-buildah repo](https://github.com/appsody/appsody-buildah)

--- a/content/docs/installing/installing-appsody.md
+++ b/content/docs/installing/installing-appsody.md
@@ -17,7 +17,7 @@ Appsody supports the following operating systems on x86 hardware:
 
 ## Requirements
 
-Appsody depends on Docker so ensure that you have [Docker](https://docs.docker.com/get-started/) installed and the Docker daemon is running on your system. Prerequisites specific to each operating system are provided within the links in the following section.
+Appsody is optimised for use with Docker so ensure that you have [Docker](https://docs.docker.com/get-started/) installed and the Docker daemon is running on your system. However, in environments where Docker is not available, Appsody can be used with Buildah instead which is detailed in the [FAQ](/docs/faq#9-can-i-use-appsody-without-docker). Prerequisites specific to each operating system are provided within the links in the following section.
 
 ## Using installers
 

--- a/content/docs/installing/installing-appsody.md
+++ b/content/docs/installing/installing-appsody.md
@@ -17,7 +17,7 @@ Appsody supports the following operating systems on x86 hardware:
 
 ## Requirements
 
-Appsody is optimised for use with Docker so ensure that you have [Docker](https://docs.docker.com/get-started/) installed and the Docker daemon is running on your system. However, in environments where Docker is not available, Appsody can be used with Buildah instead which is detailed in the [FAQ](/docs/faq#9-can-i-use-appsody-without-docker). Prerequisites specific to each operating system are provided within the links in the following section.
+To use all of Appsody's functions, you need to install [Docker](https://docs.docker.com/get-started/) and start the Docker daemon on your system. In environments where Docker is not available, a subset of Appsody commands can be used with Buildah as detailed in the [FAQ](/docs/faq#9-can-i-use-appsody-without-docker). Prerequisites specific to each operating system are provided within the links in the following section.
 
 ## Using installers
 

--- a/content/docs/using-appsody/building-and-deploying.md
+++ b/content/docs/using-appsody/building-and-deploying.md
@@ -255,8 +255,8 @@ To ensure that the latest version of your app is pushed to the cluster, use the 
 
 > This deployment option is under development
 
-Most likely, the deployment of apps created with the appsody CLI is going to occur through the invocation of a CI/CD build pipeline.
+Most likely, the deployment of apps created with the Appsody CLI is going to occur through the invocation of a CI/CD build pipeline.
 
-As a developer, you develop your app using the appsody CLI, and when you are ready to deploy, you push your code to a repo or create a pull request on GitHub.
+As a developer, you develop your app using the Appsody CLI, and when you are ready to deploy, you push your code to a repo or create a pull request on GitHub.
 
-This [example](https://github.com/appsody/tekton-example) shows you how to use Tekton pipelines to deploy your app to a Kubernetes cluster. More details on running the Tekton pipeline example for Appsody can be found in the repo [readme file] (https://github.com/appsody/tekton-example/blob/master/README.md). The example makes use of a customized Buildah image with the Appsody CLI installed which can be found [here](https://github.com/appsody/appsody-buildah).
+This [example](https://github.com/appsody/tekton-example) shows you how to use Tekton pipelines to deploy your app to a Kubernetes cluster. More details on running the Tekton pipeline example for Appsody can be found in the repo [readme file] (https://github.com/appsody/tekton-example/blob/master/README.md). The example uses a [customized Buildah image with the Appsody CLI installed](https://github.com/appsody/appsody-buildah). For more information on using Appsody with Buildah, see the [FAQ](/docs/faq#9-can-i-use-appsody-without-docker)

--- a/content/docs/using-appsody/building-and-deploying.md
+++ b/content/docs/using-appsody/building-and-deploying.md
@@ -259,4 +259,4 @@ Most likely, the deployment of apps created with the appsody CLI is going to occ
 
 As a developer, you develop your app using the appsody CLI, and when you are ready to deploy, you push your code to a repo or create a pull request on GitHub.
 
-This [example](https://github.com/appsody/tekton-example) shows you how to use Tekton pipelines to deploy your app to a Kubernetes cluster. More details on running the Tekton pipeline example for Appsody can be found in the repo [readme file] (https://github.com/appsody/tekton-example/blob/master/README.md).
+This [example](https://github.com/appsody/tekton-example) shows you how to use Tekton pipelines to deploy your app to a Kubernetes cluster. More details on running the Tekton pipeline example for Appsody can be found in the repo [readme file] (https://github.com/appsody/tekton-example/blob/master/README.md). The example makes use of a customized Buildah image with the Appsody CLI installed which can be found [here](https://github.com/appsody/appsody-buildah).


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
Mentions the `appsody-buildah` image used in the tekton example. I'm not sure how much explanation needs to be done here as the README in the repo goes into further detail.

Fixes: #539 