### PR TITLE
Fixed a Swift tutorial typo in the frontmatter

### DIFF
--- a/content/tutorials/ServerSideSwiftDevelopInXcode.md
+++ b/content/tutorials/ServerSideSwiftDevelopInXcode.md
@@ -1,5 +1,5 @@
 ---
-title: "Server-Swift Swift: Develop in Xcode, continuously verify in Docker"
+title: "Server-Side Swift: Develop in Xcode, continuously verify in Docker"
 date: "2019-09-01"
 author: "Chris Bailey"
 tutorial: "true"


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md) before opening a pull request.
-->

## Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).
- [x] website builds and runs in production - for information on how to test locally go [here](https://github.com/appsody/website/blob/master/DEVELOPMENT.md).

## Description
Fixed the typo in the front matter of the swift tutorial

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #32, Related to #54, etc.
-->
#issue-number