### PR TITLE
Remove twitter and slack icons

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -5,8 +5,6 @@ import Nav from 'react-bootstrap/Nav';
 import { Link } from "gatsby";
 
 import githubIcon from "../images/header_github_icon.svg";
-import twitterIcon from "../images/header_twitter_icon.svg";
-import slackIcon from "../images/header_slack_icon.svg";
 import appsodyLogo from "../images/appsody_logo.svg";
 
 import Search from './search';

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -25,8 +25,6 @@ const NavBar = () => (
       <Nav className="ml-auto smallscreen-social">
           <Navbar.Toggle aria-controls="basic-navbar-nav" />
           <Nav.Link href="https://github.com/appsody"><img className="navbar-img" src={ githubIcon } alt=""></img></Nav.Link>
-          <Nav.Link href="https://twitter.com/appsodydev"><img id="twitter-nav" className="navbar-img" src={ twitterIcon } alt=""></img></Nav.Link>
-          <Nav.Link href="http://appsody-slack.eu-gb.mybluemix.net"><img className="navbar-img" src={ slackIcon } alt=""></img></Nav.Link>
       </Nav>
           <Navbar.Collapse id="basic-navbar-nav">
         <Nav>
@@ -43,8 +41,6 @@ const NavBar = () => (
               <Nav className="ml-auto bigscreen-social">
           <Navbar.Toggle aria-controls="basic-navbar-nav" />
           <Nav.Link href="https://github.com/appsody"><img className="navbar-img" src={ githubIcon } alt=""></img></Nav.Link>
-          <Nav.Link href="https://twitter.com/appsodydev"><img id="twitter-nav" className="navbar-img" src={ twitterIcon } alt=""></img></Nav.Link>
-          <Nav.Link href="http://appsody-slack.eu-gb.mybluemix.net"><img className="navbar-img" src={ slackIcon } alt=""></img></Nav.Link>
       </Nav>
     </Navbar>
   </header>


### PR DESCRIPTION
This PR removes the Twitter and Slack links from the nav bar as these accounts are no longer active. 